### PR TITLE
Respect dark preference

### DIFF
--- a/com.github.jeysonflores.elementarycpp.json
+++ b/com.github.jeysonflores.elementarycpp.json
@@ -4,7 +4,12 @@
     "runtime-version": "6",
     "sdk": "io.elementary.Sdk",
     "command": "com.github.jeysonflores.elementarycpp",
-    "finish-args": ["--share=ipc", "--socket=fallback-x11", "--socket=fallback-x11" ],
+    "finish-args": [
+        "--share=ipc",
+        "--socket=fallback-x11",
+        "--socket=fallback-x11" ,
+        "--system-talk-name=org.freedesktop.Accounts"
+    ],
     "build-options" : {
         "cflags": "-O2 -g",
         "cxxflags": "-O2 -g",
@@ -91,7 +96,7 @@
                     "sha256": "829fa113daed74398c49c3f2b7672807f58ba85d0fa463f5bc726e1b0138b86b"
                 }
             ]
-        },        
+        },
         {
             "name": "elementarycpp",
             "sources": [
@@ -100,7 +105,7 @@
                     "path": "."
                 }
             ],
-            "buildsystem": "meson"      
+            "buildsystem": "meson"
         }
     ]
 }

--- a/meson.build
+++ b/meson.build
@@ -11,9 +11,10 @@ subdir('data')
 
 executable(
 	meson.project_name(),
-	['src/Application.cpp', 'src/MainWindow.cpp', ['src/MainWindow.h']],
+	['src/Application.cpp', 'src/MainWindow.cpp', ['src/Application.h', 'src/MainWindow.h']],
 	dependencies: [
 		dependency('gtkmm-3.0'),
+		dependency('granite'),
 	],
 	install: true
 )

--- a/src/Application.cpp
+++ b/src/Application.cpp
@@ -1,29 +1,48 @@
+#include "Application.h"
 #include "MainWindow.h"
-#include <memory>
-#include <gtkmm.h>
 
+Application::Application()
+: Gtk::Application("com.github.jeysonflores.elementarycpp")
+{
+}
 
-using namespace Glib;
-using namespace Gtk;
+Glib::RefPtr<Application> Application::create()
+{
+	return Glib::RefPtr<Application>(new Application());
+}
 
+void Application::on_prefers_color_scheme_changed()
+{
+	auto granite_settings = granite_settings_get_default();
+	auto gtk_settings = Gtk::Settings::get_default();
+	auto colour_scheme = granite_settings_get_prefers_color_scheme(granite_settings);
 
-int main (int argc, char *argv[]) {
+	gtk_settings->property_gtk_application_prefer_dark_theme().set_value(colour_scheme == GRANITE_SETTINGS_COLOR_SCHEME_DARK);
+}
 
-	RefPtr<Gtk::Application> application = Gtk::Application::create(argc, argv);
-	application -> set_id("com.github.jeysonflores.elementarycpp");
-	
+void Application::on_activate()
+{
+	// Initially set the preferred colour scheme
+	on_prefers_color_scheme_changed();
+
+	// Listen for changes to the colour scheme
+	auto granite_settings = granite_settings_get_default();
+	g_signal_connect(granite_settings, "notify::prefers-color-scheme", G_CALLBACK(&on_prefers_color_scheme_changed), NULL);
+
+	auto appwindow = new MainWindow();
+	add_window(*appwindow);
+
 	auto m_settings = Gio::Settings::create("com.github.jeysonflores.elementarycpp");
 	auto window_width = m_settings -> get_int ("window-width");
 	auto window_height = m_settings -> get_int("window-height");
 	auto pos_x = m_settings -> get_int("pos-x");
 	auto pos_y = m_settings -> get_int("pos-y");
 
-	MainWindow main_window;
-
-	main_window.resize(window_width, window_height);
-	main_window.move(pos_x,pos_y);
-
-	return application->run(main_window);
+	appwindow -> resize(window_width, window_height);
+	appwindow -> move(pos_x,pos_y);
 }
 
-
+int main (int argc, char *argv[]) {
+	auto application = Application::create();
+	return application->run(argc, argv);
+}

--- a/src/Application.h
+++ b/src/Application.h
@@ -1,0 +1,19 @@
+#pragma once
+
+#include <gtkmm.h>
+#include <granite.h>
+
+class Application : public Gtk::Application
+{
+	protected:
+		Application();
+
+	public:
+		static Glib::RefPtr<Application> create();
+
+	protected:
+		void on_activate() override;
+
+	private:
+		static void on_prefers_color_scheme_changed();
+};

--- a/src/MainWindow.h
+++ b/src/MainWindow.h
@@ -2,7 +2,7 @@
 
 #include <gtkmm.h>
 
-class MainWindow : public Gtk::Window
+class MainWindow : public Gtk::ApplicationWindow
 {
 public:
 	MainWindow();


### PR DESCRIPTION
Uses Granite to read and listen for changes to the user's dark style preference. I've essentially written the Granite parts in C, rather than gtkmm style C++ since there aren't gtkmm bindings for Granite.